### PR TITLE
Fix prepareFastGapFill bug related to KEGGMatrix

### DIFF
--- a/src/reconstruction/fastGapFill/AuxillaryFiles/generateSUXComp.m
+++ b/src/reconstruction/fastGapFill/AuxillaryFiles/generateSUXComp.m
@@ -43,7 +43,7 @@ end
 
 % create KEGG Matrix - U
 if ~exist('KEGGMatrixLoad', 'var')
-    KEGGMatrixLoad = 1;
+    KEGGMatrixLoad = 0;
 end
 if KEGGMatrixLoad
     load KEGGMatrix


### PR DESCRIPTION
Rectifies KEGGMatrixLoad default value.

The bug was mentioned [here](https://groups.google.com/g/cobra-toolbox/c/bXG5ZAZPFZk).
When executing prepareFastGapFill this error happens:
```
Error using load
Unable to read file 'KEGGMatrix'. No such file or directory.

Error in generateSUXComp (line 49)
    load KEGGMatrix

Error in prepareFastGapFill (line 86)
MatricesSUX = generateSUXComp(consistModel,dictionary, filename,blackList,listCompartments);
```
In the comments says that the default values for KEGGMatrixLoad is 0 but in the code is 1 which makes it try to load something that hasn't been downloaded, jet.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
